### PR TITLE
Implement `Hydrate` for `Box<T>`

### DIFF
--- a/autosurgeon/src/hydrate/impls.rs
+++ b/autosurgeon/src/hydrate/impls.rs
@@ -109,3 +109,13 @@ impl<'a, T: Hydrate + Clone> Hydrate for Cow<'a, T> {
         Ok(Cow::Owned(T::hydrate(doc, obj, prop)?))
     }
 }
+
+impl<T: Hydrate> Hydrate for Box<T> {
+    fn hydrate<'a, D: ReadDoc>(
+        doc: &D,
+        obj: &automerge::ObjId,
+        prop: crate::Prop<'a>,
+    ) -> Result<Self, HydrateError> {
+        Ok(Box::new(T::hydrate(doc, obj, prop)?))
+    }
+}


### PR DESCRIPTION
There is already a `impl<T: Reconcile> Reconcile for Box<T>` but the implementation for `Hydrate` is missing. Not sure if there is a specific reason for that, but adding this `impl` allows me to use `autosurgeon` on my `structs` that have `Box` and `Option<Box>` fields.