### PR TITLE
Delete old keys when updating an enum between variants

### DIFF
--- a/autosurgeon-derive/tests/reconcile.rs
+++ b/autosurgeon-derive/tests/reconcile.rs
@@ -487,6 +487,29 @@ fn reconcile_tuple_enum_key() {
     );
 }
 
+#[test]
+fn reconcile_between_enum_variants() {
+    let mut doc = automerge::AutoCommit::new();
+    let temp = TempReading::Celsius("one".to_string(), 1.2);
+    reconcile_prop(&mut doc, automerge::ROOT, "temp", &temp).unwrap();
+
+    let temp = TempReading::Fahrenheit("three".to_string(), 6.7);
+    reconcile_prop(&mut doc, automerge::ROOT, "temp", &temp).unwrap();
+
+    assert_doc!(
+        doc.document(),
+        map! {
+            "temp" => { map! {
+                    "Fahrenheit" => { list! {
+                        { "three" },
+                        { 6.7_f64 },
+                    } }
+                }
+            }
+        }
+    );
+}
+
 mod enumkeyvisibility {
     use autosurgeon::Reconcile;
 

--- a/autosurgeon/src/reconcile.rs
+++ b/autosurgeon/src/reconcile.rs
@@ -153,7 +153,7 @@ pub trait MapReconciler {
             }
         }
         for k in &delenda {
-            self.delete(&k)?;
+            self.delete(k)?;
         }
         Ok(())
     }

--- a/autosurgeon/src/reconcile.rs
+++ b/autosurgeon/src/reconcile.rs
@@ -138,6 +138,25 @@ pub trait MapReconciler {
         self.put(prop, value)?;
         Ok(())
     }
+
+    /// Remove any entries that do not satisfy the given predicate.
+    fn retain<F: FnMut(&str, automerge::Value) -> bool>(
+        &mut self,
+        mut pred: F,
+    ) -> Result<(), Self::Error> {
+        // TODO: a more efficient implementation might be possible with
+        // an addition to Automerge
+        let mut delenda = Vec::new();
+        for (k, v) in self.entries() {
+            if !pred(k, v) {
+                delenda.push(k.to_string());
+            }
+        }
+        for k in &delenda {
+            self.delete(&k)?;
+        }
+        Ok(())
+    }
 }
 
 /// A node in the document which is an `automerge::List`


### PR DESCRIPTION
Fixes #17.

This adds a new `retain` method to `MapReconciler`. Currently, the implementation is collecting all of the keys that need to be deleted, then iterating through that list; because of borrowing issues, the keys have to be cloned into `String`s. It might be possible to implement an addition to Automerge that can do this more efficiently.