### PR TITLE
Derive Clone for both Text and Counter

### DIFF
--- a/autosurgeon/src/counter.rs
+++ b/autosurgeon/src/counter.rs
@@ -33,6 +33,7 @@ use crate::{reconcile::CounterReconciler, Hydrate, Reconcile};
 /// let stats: Stats = hydrate(&doc).unwrap();
 /// assert_eq!(stats.num_clicks.value(), 8);
 /// ```
+#[derive(Clone)]
 pub struct Counter(State);
 
 impl std::fmt::Debug for Counter {
@@ -49,6 +50,7 @@ impl std::default::Default for Counter {
     }
 }
 
+#[derive(Clone)]
 enum State {
     Fresh(i64),
     Rehydrated { original: i64, increment: i64 },

--- a/autosurgeon/src/text.rs
+++ b/autosurgeon/src/text.rs
@@ -48,6 +48,7 @@ use crate::{
 /// let quote: Quote = hydrate(&doc).unwrap();
 /// assert_eq!(quote.text.as_str(), "All that glitters is not gold");
 /// ```
+#[derive(Clone)]
 pub struct Text(State);
 
 impl std::default::Default for Text {
@@ -124,6 +125,7 @@ impl<S: AsRef<str>> From<S> for Text {
     }
 }
 
+#[derive(Clone)]
 enum State {
     Fresh(String),
     Rehydrated {
@@ -133,6 +135,7 @@ enum State {
     },
 }
 
+#[derive(Clone)]
 struct Splice {
     pos: usize,
     delete: usize,


### PR DESCRIPTION
`Clone` is often required to be implemented/derived for user-space structs/enums that might include `Text` and `Counter`.  However, currently users are unable to derive `Clone` on parent structs/enums that include `Text` and `Counter` as members.

This PR derives `Clone` for `Text` and `Counter` to make these types easier to use.