### PR TITLE
Add Reconcile::Key to Uuid

### DIFF
--- a/autosurgeon/src/uuid.rs
+++ b/autosurgeon/src/uuid.rs
@@ -1,14 +1,39 @@
 use std::mem;
 
+use automerge::{ScalarValue, Value};
 use uuid::Uuid;
 
-use crate::{bytes::ByteArray, Hydrate, HydrateError, Reconcile};
+use crate::{bytes::ByteArray, reconcile::LoadKey, Hydrate, HydrateError, ReadDoc, Reconcile};
 
 impl Reconcile for Uuid {
-    type Key<'a> = <ByteArray<{ mem::size_of::<Uuid>() }> as Reconcile>::Key<'a>;
+    type Key<'a> = Uuid;
 
     fn reconcile<R: crate::Reconciler>(&self, reconciler: R) -> Result<(), R::Error> {
         ByteArray::from(*self.as_bytes()).reconcile(reconciler)
+    }
+
+    fn key(&self) -> LoadKey<Self::Key<'_>> {
+        LoadKey::Found(*self)
+    }
+
+    fn hydrate_key<'a, D: ReadDoc>(
+        doc: &D,
+        obj: &automerge::ObjId,
+        prop: crate::Prop<'_>,
+    ) -> Result<LoadKey<Self::Key<'a>>, crate::ReconcileError> {
+        Ok(match doc.get(obj, &prop)? {
+            Some((Value::Scalar(s), _)) => {
+                if let ScalarValue::Bytes(b) = s.as_ref() {
+                    match Uuid::from_slice(b) {
+                        Ok(u) => LoadKey::Found(u),
+                        Err(_) => LoadKey::KeyNotFound,
+                    }
+                } else {
+                    LoadKey::KeyNotFound
+                }
+            }
+            _ => LoadKey::KeyNotFound,
+        })
     }
 }
 
@@ -36,5 +61,25 @@ mod tests {
         let hydrated_uuid = hydrate_prop(&doc, ObjId::Root, "secret").unwrap();
 
         assert_eq!(uuid, hydrated_uuid);
+    }
+
+    #[test]
+    fn uuid_keys() {
+        let uuid0 = Uuid::new_v4();
+        let uuid1 = Uuid::new_v4();
+
+        // Vec with two UUIDs
+        let mut doc1 = automerge::AutoCommit::new();
+        reconcile_prop(&mut doc1, ObjId::Root, "vec", vec![uuid0, uuid1]).unwrap();
+
+        // Fork document, remove first UUID in doc1, and second UUID in doc2
+        let mut doc2 = doc1.fork();
+        reconcile_prop(&mut doc1, ObjId::Root, "vec", vec![uuid1]).unwrap();
+        reconcile_prop(&mut doc2, ObjId::Root, "vec", vec![uuid0]).unwrap();
+
+        // Merge documents together: both UUIDs should be gone
+        doc1.merge(&mut doc2).unwrap();
+        let hydrated_vec: Vec<Uuid> = hydrate_prop(&doc1, ObjId::Root, "vec").unwrap();
+        assert_eq!(Vec::<Uuid>::new(), hydrated_vec);
     }
 }


### PR DESCRIPTION
Sets the `Key` associated type in the impl of `Reconcile` for `Uuid`.