### PR TITLE
Add extra-traits feature to syn

### DIFF
--- a/autosurgeon-derive/Cargo.toml
+++ b/autosurgeon-derive/Cargo.toml
@@ -13,7 +13,7 @@ proc_macro = true
 
 [dependencies]
 quote = "1.0.21"
-syn = { version = "2", features = ["full"] }
+syn = { version = "2", features = ["full", "extra-traits"] }
 proc-macro2 = "1.0"
 smol_str = { version = "^0.1.21" }
 thiserror = "1.0.37"


### PR DESCRIPTION
Fixing the below error(and other similar ones) on `1.71.0-nightly`

` binary operation `==` cannot be applied to type `Cow<'_, syn::Field>``

See https://stackoverflow.com/questions/63677722/binary-operation-cannot-be-applied-to-type-synpath