### PR TITLE
Add Text::update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ repository = "https://github.com/automerge/autosurgeon"
 license = "MIT"
 
 [workspace.dependencies]
-automerge = "0.5.0"
-automerge-test = "0.4.0"
+automerge = "0.5"
+automerge-test = "0.4"

--- a/autosurgeon-derive/tests/text.rs
+++ b/autosurgeon-derive/tests/text.rs
@@ -1,0 +1,31 @@
+use autosurgeon::Text;
+use autosurgeon::{Hydrate, Reconcile};
+
+#[derive(Hydrate, Reconcile)]
+struct TextDoc {
+    content: Text,
+}
+
+#[test]
+fn diff_generates_splices() {
+    let start = TextDoc {
+        content: Text::with_value("some value"),
+    };
+
+    let mut doc = automerge::AutoCommit::new();
+    autosurgeon::reconcile(&mut doc, &start).unwrap();
+    let mut doc2 = doc.fork();
+
+    let mut start2 = autosurgeon::hydrate::<_, TextDoc>(&doc).unwrap();
+    start2.content.update("some day");
+    autosurgeon::reconcile(&mut doc, &start2).unwrap();
+
+    let mut start3 = autosurgeon::hydrate::<_, TextDoc>(&doc2).unwrap();
+    start3.content.update("another value");
+    autosurgeon::reconcile(&mut doc2, &start3).unwrap();
+
+    doc.merge(&mut doc2).unwrap();
+
+    let start3 = autosurgeon::hydrate::<_, TextDoc>(&doc).unwrap();
+    assert_eq!(start3.content.as_str(), "another day");
+}

--- a/autosurgeon/Cargo.toml
+++ b/autosurgeon/Cargo.toml
@@ -12,7 +12,7 @@ license = { workspace = true }
 [dependencies]
 automerge = { workspace = true }
 autosurgeon-derive = { path = "../autosurgeon-derive", version = "0.8.0" }
-similar = "2.2.1"
+similar = { version = "2.2.1", features = ["unicode"] }
 thiserror = "1.0.37"
 uuid = { version = "1.2.2", optional = true }
 


### PR DESCRIPTION
Problem: sometimes when modifying text you are not able to capture the edits to the text field as they happen. For example, if the text is in a file and you just get notified when the file has changed then you have no way of knowing which text was inserted and deleted. The `Text` API requires that you express all changes as `splice` calls, so the user is forced to figure out how to turn the new value into a set of `splice` calls, which can be tricky.

Solution: add `Text::update`, which performs an LCS diff to figure out a minimal set of `splice` calls to perform internally.