### PR TITLE
Hide derived reconcile enums from docs

### DIFF
--- a/autosurgeon-derive/src/reconcile/enum_impl.rs
+++ b/autosurgeon-derive/src/reconcile/enum_impl.rs
@@ -545,6 +545,7 @@ impl<'a> EnumKey<'a> {
         };
         let span = Span::mixed_site();
         Some(quote_spanned! {span=>
+            #[doc(hidden)]
             #[derive(::std::clone::Clone, ::std::cmp::PartialEq)]
             #[allow(clippy::derive_partial_eq_without_eq)]
             #vis enum #name_with_lifetime {


### PR DESCRIPTION
Whithout this we have to `#![allow(missing_docs)]` since our lints enforce it but we cannot document these generated enums.