### PR TITLE
[feat] untagged enums 

### DIFF
--- a/autosurgeon-derive/src/attrs.rs
+++ b/autosurgeon-derive/src/attrs.rs
@@ -6,6 +6,7 @@ use syn::spanned::Spanned;
 pub(crate) struct Container {
     reconcile_with: Option<ReconcileWith>,
     hydrate_with: Option<HydrateWith>,
+    untagged: bool,
 }
 
 impl Container {
@@ -19,6 +20,7 @@ impl Container {
                 result = Some(Container {
                     reconcile_with: ReconcileWith::from_attrs(&attrs)?,
                     hydrate_with: HydrateWith::from_attrs(&attrs)?,
+                    untagged: attrs.untagged,
                 });
             }
         }
@@ -31,6 +33,10 @@ impl Container {
 
     pub(crate) fn hydrate_with(&self) -> Option<TokenStream> {
         self.hydrate_with.as_ref().map(|h| h.hydrate_with())
+    }
+    
+    pub(crate) fn untagged(&self) -> bool {
+        self.untagged
     }
 }
 
@@ -347,6 +353,7 @@ struct AutosurgeonAttrs {
     hydrate: Option<syn::Path>,
     missing: Option<syn::Path>,
     rename: Option<String>,
+    untagged: bool
 }
 
 impl AutosurgeonAttrs {
@@ -359,6 +366,7 @@ impl AutosurgeonAttrs {
             hydrate: None,
             missing: None,
             rename: None,
+            untagged: false
         };
         attr.parse_nested_meta(|meta| {
             if meta.path.is_ident("reconcile") {
@@ -385,7 +393,9 @@ impl AutosurgeonAttrs {
                 let value = meta.value()?;
                 let s: syn::LitStr = value.parse()?;
                 result.rename = Some(s.value());
-            } else {
+            } else if meta.path.is_ident("untagged") {
+                result.untagged = true;
+        } else {
                 return Err(meta.error("unknown attribute"));
             }
             Ok(())

--- a/autosurgeon-derive/src/hydrate.rs
+++ b/autosurgeon-derive/src/hydrate.rs
@@ -1,10 +1,10 @@
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, quote_spanned};
-use syn::{
-    parse_macro_input, parse_quote, spanned::Spanned, DeriveInput, Fields, GenericParam, Generics,
-};
+use syn::{parse_macro_input, parse_quote, spanned::Spanned, DeriveInput, Fields, GenericParam, Generics};
 
 use crate::attrs;
+use crate::hydrate::error::DeriveError;
+
 mod named_field;
 mod newtype_field;
 mod unnamed_field;
@@ -28,7 +28,11 @@ pub fn derive_hydrate(input: proc_macro::TokenStream) -> proc_macro::TokenStream
 
     let result = match &input.data {
         syn::Data::Struct(datastruct) => on_struct(&input, datastruct),
-        syn::Data::Enum(dataenum) => on_enum(&input, dataenum),
+        syn::Data::Enum(dataenum) => if container_attrs.untagged() {
+            on_enum_untagged(&input, dataenum)
+        } else {
+            on_enum(&input, dataenum)
+        },
         _ => todo!(),
     };
     let tokens = match result {
@@ -126,6 +130,86 @@ fn on_enum(
             #hydrate_string
 
             #hydrate_map
+        }
+    })
+}
+
+fn on_enum_untagged(
+    input: &DeriveInput,
+    enumstruct: &syn::DataEnum,
+) -> Result<TokenStream, error::DeriveError> {
+
+    let name = &input.ident;
+
+    let matches: Vec<proc_macro2::TokenStream> = enumstruct.variants
+        .iter()
+        .map(|v| {
+            let variant = &v.ident;
+
+            match &v.fields {
+                syn::Fields::Unit => Err(DeriveError::Untagged(None)),
+                syn::Fields::Unnamed(fields) => {
+                    if fields.unnamed.len() == 1 {
+                        let field = fields.unnamed.first().unwrap();
+                        let inner_type = match &field.ty {
+                            syn::Type::Path(path) => &path.path.segments[0].ident,
+                            _ => panic!("Expected a type path for variant {}", variant),
+                        };
+
+                        Ok(quote! {
+                            let result = #inner_type::hydrate_map(doc, obj);
+                            if result.is_ok() {
+                                return Ok(#name::#variant(result?))
+                            }
+                        })
+                    } else {
+                        Err(DeriveError::Untagged(Some(fields.span())))
+                    }
+                }
+                syn::Fields::Named(field) => Err(DeriveError::Untagged(Some(field.span()))),
+            }
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(quote! {
+        impl autosurgeon::Hydrate for #name {
+            fn hydrate_map<D: autosurgeon::ReadDoc>(doc: &D, obj: &automerge::ObjId) -> Result<Self, autosurgeon::HydrateError> {
+                let Some(obj_type) = doc.object_type(obj) else {
+                    return Err(autosurgeon::HydrateError::unexpected(
+                        "a value matching to any of the members of the untagged enum",
+                        "a scalar value".to_string(),
+                    ));
+                };
+
+                match obj_type {
+                    automerge::ObjType::Map | automerge::ObjType::Table => {
+                        let entries: Vec<String> = doc
+                            .map_range(obj.clone(), ..)
+                            .map(|item| {
+                                item.key.to_string()
+                            })
+                            .collect();
+
+                        #(#matches)*
+
+                        Err(autosurgeon::HydrateError::unexpected(
+                            "a value matching to any of the members of the untagged enum",
+                            format!(
+                                "a structure with the following fields: {:?}",
+                                entries
+                            ),
+                        ))
+                    }
+                    automerge::ObjType::Text => Err(autosurgeon::HydrateError::unexpected(
+                        "a value matching to any of the members of the untagged enum",
+                        "a text object".to_string(),
+                    )),
+                    automerge::ObjType::List => Err(autosurgeon::HydrateError::unexpected(
+                        "a value matching to any of the members of the untagged enum",
+                        "a list object".to_string(),
+                    )),
+                }
+            }
         }
     })
 }
@@ -374,6 +458,8 @@ mod error {
         InvalidFieldAttrs(#[from] syn::parse::Error),
         #[error("cannot derive hydrate for unit struct")]
         HydrateForUnit,
+        #[error("untagged is only available on Enums with exclusively newtype fields")]
+        Untagged(Option<Span>),
     }
 
     impl DeriveError {
@@ -381,6 +467,7 @@ mod error {
             match self {
                 Self::InvalidFieldAttrs(e) => Some(e.span()),
                 Self::HydrateForUnit => None,
+                Self::Untagged(span) => *span,
             }
         }
     }

--- a/autosurgeon-derive/src/reconcile.rs
+++ b/autosurgeon-derive/src/reconcile.rs
@@ -121,7 +121,11 @@ fn reconcile_impl(
             }
             Fields::Unit => Err(error::DeriveError::Unit),
         },
-        Data::Enum(ref data) => enum_impl::enum_impl(vis, name, generics, reconciler_ident, data),
+        Data::Enum(ref data) => if container_attrs.untagged() {
+            enum_impl::enum_untagged_impl(vis, name, data)
+        } else {
+            enum_impl::enum_impl(vis, name, generics, reconciler_ident, data)
+        },
         Data::Union(_) => Err(error::DeriveError::Union),
     }
 }
@@ -280,6 +284,8 @@ mod error {
         Unit,
         #[error("cannot derive Reconcile for a Union")]
         Union,
+        #[error("untagged is only available on Enums with exclusively newtype fields")]
+        Untagged(Span),
         #[error(transparent)]
         Syn(#[from] syn::Error),
     }
@@ -290,6 +296,7 @@ mod error {
                 Self::InvalidKeyAttr(e) => e.span(),
                 Self::Unit => None,
                 Self::Union => None,
+                Self::Untagged(span) => Some(*span),
                 Self::Syn(s) => Some(s.span()),
             }
         }

--- a/autosurgeon-derive/src/reconcile/enum_impl.rs
+++ b/autosurgeon-derive/src/reconcile/enum_impl.rs
@@ -183,6 +183,19 @@ impl Variant<'_> {
             }
         }
     }
+
+    fn match_arm_untagged(&self, outer_ty: &syn::Ident) -> Result<proc_macro2::TokenStream, DeriveError> {
+        match self {
+            Self::Unit { name, .. } => Err(DeriveError::Untagged(name.span())),
+            Self::NewType { name, .. } => {
+                    Ok(quote! {
+                        #outer_ty::#name(item) => item.reconcile(reconciler),
+                    })
+                }
+            Self::Named { name, .. } => Err(DeriveError::Untagged(name.span())),
+            Self::Unnamed { name, .. } => Err(DeriveError::Untagged(name.span())),
+        }
+    }
 }
 
 #[derive(PartialEq, Eq)]
@@ -687,6 +700,41 @@ pub(super) fn enum_impl(
             #( #matches),*
         }
     };
+    Ok(ReconcileImpl {
+        key_type: enumkey.key_type(),
+        reconcile,
+        hydrate_key: enumkey.hydrate_key(),
+        get_key: enumkey.get_key(),
+        key_type_def: enumkey.type_def(vis),
+    })
+}
+
+pub(super) fn enum_untagged_impl(
+    vis: &syn::Visibility,
+    name: &syn::Ident,
+    data: &syn::DataEnum,
+) -> Result<ReconcileImpl, DeriveError> {
+    let variants = data
+        .variants
+        .iter()
+        .map(Variant::try_from)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let matches = variants.iter().try_fold::<_, _, Result<_, DeriveError>>(
+        Vec::new(),
+        |mut results, v| {
+            results.push(v.match_arm_untagged(name)?);
+            Ok(results)
+        },
+    )?;
+
+    let reconcile = quote! {
+        match self {
+            #(#matches)*
+        }
+    };
+
+    let enumkey = EnumKey::from_variants(name, variants.iter())?;
     Ok(ReconcileImpl {
         key_type: enumkey.key_type(),
         reconcile,


### PR DESCRIPTION
This implements untagged enums similar to untagged enums in serde_json, to create a way of parsing documents with different datatypes contained in one array, without having to write a custom hydrator and reconciler for that every time.

If you have any questions, suggestions, changes, or ideas for doing this better, it take a while for me to respond.