### PR TITLE
feat: support automerge 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ repository = "https://github.com/automerge/autosurgeon"
 license = "MIT"
 
 [workspace.dependencies]
-automerge = "0.8.0"
-automerge-test = "0.7.0"
+automerge = "0.9"
+automerge-test = "0.9"


### PR DESCRIPTION
## Summary

Updates `automerge` dependency from `^0.8.0` to `^0.9.0` and `automerge-test` from `^0.7.0` to `^0.9`.

## Motivation

automerge 0.9.0 is the latest stable release with updated dependencies (getrandom 0.4, rand 0.10, sha2 0.11, etc.). Users of autosurgeon who want to use the latest automerge cannot do so without this change.

## Testing

All existing tests pass with `automerge = "0.9"` and `automerge-test = "0.9"`:
- Unit tests (lib)
- Integration tests (derive macros)
- Doc tests

\`\`\`bash
cargo test -p autosurgeon -p autosurgeon-derive
\`\`\`

## Checklist

- [x] Tests pass
- [x] cargo check / clippy clean
- [ ] CHANGELOG updated (up to maintainer discretion)